### PR TITLE
Use plain (non-development) version of structlog in requirements.in

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,2 +1,3 @@
+colorama
 simplejson
 structlog

--- a/requirements.in
+++ b/requirements.in
@@ -1,2 +1,2 @@
 simplejson
-structlog[dev]
+structlog

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@
 #
 #    pip-compile --no-index --output-file requirements.txt requirements.in
 #
-colorama==0.3.9           # via structlog
 simplejson==3.13.2
 six==1.11.0               # via structlog
-structlog[dev]==17.2.0
+structlog==17.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 #
 #    pip-compile --no-index --output-file requirements.txt requirements.in
 #
+colorama==0.4.1
 simplejson==3.13.2
 six==1.11.0               # via structlog
 structlog==17.2.0


### PR DESCRIPTION
The development version has many development-and-testing-related
dependencies like `pytest`, which are unnecessary for regular usage.